### PR TITLE
Fix typo in constructing a /feedback link

### DIFF
--- a/popups/scratch-messaging/popup.js
+++ b/popups/scratch-messaging/popup.js
@@ -321,7 +321,7 @@ export default async ({ addon, msg, safeMsg }) => {
     computed: {
       feedbackUrl() {
         const manifest = chrome.runtime.getManifest();
-        return `https://scratchaddons.com/feedback/?ext_version=${manifest.version_name}&utm_source=extension&utm_medium=messagingcrash&utm_campaign=v${manifest.versions}`;
+        return `https://scratchaddons.com/feedback/?ext_version=${manifest.version_name}&utm_source=extension&utm_medium=messagingcrash&utm_campaign=v${manifest.version}`;
       },
       profilesOrdered() {
         // Own profile first, then others


### PR DESCRIPTION
<!-- Which issue(s) does this pull request fix or resolve? -->

Resolves plausible showing `vundefined`

### Changes

fixes typo
### Reason for changes

it's a bug